### PR TITLE
Make path relative to module location

### DIFF
--- a/Get-Quote.psm1
+++ b/Get-Quote.psm1
@@ -45,7 +45,7 @@ Function Get-Quote {
 [OutputType([String])]
 [Alias('Cookie')]
 Param (
-    $QuoteFile = '.\Fortunes.dat'
+    $QuoteFile = "$PsScriptRoot\Fortunes.dat"
 )
 
     # Use a filestream to randomly read the quote file


### PR DESCRIPTION
When I downloaded the module from gallery I was greeted by error that told me that the .dat cannot be found in my "C:\Windows\System32\WindowsPowerShell\v1.0\", the current path was probably set to that location. 
The dat file is placed in path relative to where the module is stored so I changed the code to reflect that. 
